### PR TITLE
feat(ArtGen): complete overhaul into reusable components + GraphQL in…

### DIFF
--- a/client/src/assets/css/artGen.css
+++ b/client/src/assets/css/artGen.css
@@ -1,88 +1,16 @@
-:root {
-  --background-color: #161616;
-  --font-color: #FFFFFF;
-  --grey: #282828;
-  --purple: #9F34FF;
-  --light-purple: #E1CDF2;
+.artgen-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  max-width: 1200px;
+  padding: 10% 2%;
+  width: min(88%, 1200px);
+  margin-inline: auto;
+  margin-bottom: 20%;
 }
 
-.artGen-flex {
-  display: flex;
-}
-
-.artGen-flex-wrap {
-  flex-wrap: wrap;
-}
-
-.artGen-flex-col {
-  flex-direction: column;
-}
-
-.artGen-gap {
-  /* gap: 1rem; */
-  gap: clamp(1rem, 4vw, 6rem);
-}
-
-.artGen-my-p5 {
-  margin-top: .5rem;
-  margin-bottom: .5rem;
-}
-
-.artGen-content-center {
-  justify-content: center;
-}
-
-.artGen-items-center {
-  align-items: center;
-}
-
-.artGen-border-radius {
-  border-radius: .5rem;
-}
-
-.artGen-object-cover {
-  object-fit: cover;
-}
-
-.artGen-font {
-  color: var(--font-color);
-  font-family: Poppins, sans-serif;
-}
-
-/* Art Section */
-.artGen-container {
-  padding: 0 3rem;
-  height: 100%;
-  background-color: var(--background-color);
-}
-
-.artGen-inner-box {
-  background-color: var(--grey);
-  padding: 1rem;
-  width: 80%;
-}
-
-.artGen-preview {
-  margin: 1rem 0;
-  /* width: clamp(256px, 40rem, 1024px);
-  height: clamp(256px, 40rem, 1024px); */
-  width: clamp(5rem, 50vw, 40rem);
-  height: clamp(5rem, 50vw, 40rem);
-  object-fit: cover;
-  /* object-fit: fill; */
-  background-color: var(--background-color);
-}
-
-.artGen-inputBox {
-  width: 100%;
-}
-
-.artGen-gen-button {
-  background-color: var(--purple);
-  min-width: 5rem;
-}
-
-.artGen-save-button {
-  background-color: var(--purple);
-  margin-top: 3rem;
+@media (min-width: 950px) {
+  .artgen-container {
+    grid-template-columns: 380px 1fr;
+  }
 }

--- a/client/src/components/artgen/ActionBar.jsx
+++ b/client/src/components/artgen/ActionBar.jsx
@@ -1,0 +1,25 @@
+// import '../../assets/css/artGen.css';
+import './action-bar.css';
+
+function ActionBar({ disabled, onSetAvatar, onSave }) {
+  return (
+    <div className="artgen-actionbar">
+      <button
+        className="artgen-secondary-btn"
+        onClick={onSetAvatar}
+        disabled={disabled}
+      >
+        Set as Profile Picture
+      </button>
+      <button
+        className="artgen-secondary-btn"
+        onClick={onSave}
+        disabled={disabled}
+      >
+        Save to Gallery
+      </button>
+    </div>
+  );
+}
+
+export default ActionBar;

--- a/client/src/components/artgen/ImagePreview.jsx
+++ b/client/src/components/artgen/ImagePreview.jsx
@@ -1,0 +1,25 @@
+import LoadingSpinner from './LoadingSpinner.jsx';
+// import '../../assets/css/artGen.css';
+import './image-preview.css';
+
+function ImagePreview({ src, isLoading }) {
+  return (
+    <div className="artgen-preview-card">
+      {!src && !isLoading && (
+        <p className="artgen-preview-placeholder">Image Preview</p>
+      )}
+
+      {isLoading && <LoadingSpinner />}
+
+      {src && !isLoading && (
+        <img
+          className="artgen-preview-image"
+          src={src}
+          alt="Generated preview"
+        />
+      )}
+    </div>
+  );
+}
+
+export default ImagePreview;

--- a/client/src/components/artgen/LoadingSpinner.jsx
+++ b/client/src/components/artgen/LoadingSpinner.jsx
@@ -1,0 +1,19 @@
+import { motion } from 'framer-motion';
+// import '../../assets/css/artGen.css';
+import './loading-spinner.css';
+
+function LoadingSpinner({ small = false }) {
+  return (
+    <motion.div
+      className={small ? 'artgen-spinner artgen-spinner--sm' : 'artgen-spinner'}
+      animate={{ rotate: 360 }}
+      transition={{
+        repeat: Infinity,
+        duration: 0.6,
+        ease: 'linear',
+      }}
+    />
+  );
+}
+
+export default LoadingSpinner;

--- a/client/src/components/artgen/PromtForm.jsx
+++ b/client/src/components/artgen/PromtForm.jsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import LoadingSpinner from './LoadingSpinner.jsx';
+// import '../../assets/css/artGen.css';
+import './prompt-form.css'
+
+function PromptForm({ onSubmit, isLoading }) {
+  const [form, setForm] = useState({
+    character: '',
+    style: '',
+    mood: '',
+    palette: '',
+    notes: '',
+  });
+
+  const handleChange = (e) =>
+    setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(form);
+  };
+
+  return (
+    <motion.form
+      onSubmit={handleSubmit}
+      className="artgen-form"
+      initial={{ opacity: 0, x: -25 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.3 }}
+    >
+      <label className="artgen-field">
+        <span>Character / Subject</span>
+        <input
+          name="character"
+          value={form.character}
+          onChange={handleChange}
+          required
+        />
+      </label>
+
+      <label className="artgen-field">
+        <span>Style</span>
+        <select name="style" value={form.style} onChange={handleChange} required>
+          <option value="" disabled>
+            Select…
+          </option>
+          <option value="pixel art">Pixel Art</option>
+          <option value="comic book">Comic Book</option>
+          <option value="realistic">Realistic</option>
+          <option value="anime">Anime</option>
+        </select>
+      </label>
+
+      <label className="artgen-field">
+        <span>Mood</span>
+        <select name="mood" value={form.mood} onChange={handleChange}>
+          <option value="">Optional</option>
+          <option value="bright">Bright</option>
+          <option value="dark">Dark</option>
+          <option value="nostalgic">Nostalgic</option>
+        </select>
+      </label>
+
+      <label className="artgen-field">
+        <span>Color Palette</span>
+        <input
+          name="palette"
+          value={form.palette}
+          onChange={handleChange}
+          placeholder="e.g. cool blues"
+        />
+      </label>
+
+      <label className="artgen-field">
+        <span>Additional Notes</span>
+        <input
+          name="notes"
+          value={form.notes}
+          onChange={handleChange}
+          placeholder="lighting, camera angle..."
+        />
+      </label>
+
+      <button
+        className="artgen-generate-btn"
+        type="submit"
+        disabled={isLoading}
+      >
+        {isLoading ? <LoadingSpinner small /> : 'Generate'}
+      </button>
+    </motion.form>
+  );
+}
+
+export default PromptForm;

--- a/client/src/components/artgen/action-bar.css
+++ b/client/src/components/artgen/action-bar.css
@@ -1,0 +1,24 @@
+.artgen-actionbar {
+  display: flex;
+  gap: 1rem;
+}
+
+.artgen-secondary-btn {
+  flex: 1;
+  padding: 0.65rem;
+  border: 1px solid #2e2e2e;
+  border-radius: 0.75rem;
+  background: transparent;
+  color: #ffffff;
+  cursor: pointer;
+  transition: background 0.25s ease-in-out;
+}
+
+.artgen-secondary-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.artgen-secondary-btn:hover:not(:disabled) {
+  background: #2e2e2e;
+}

--- a/client/src/components/artgen/image-preview.css
+++ b/client/src/components/artgen/image-preview.css
@@ -1,0 +1,27 @@
+.artgen-preview-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.artgen-preview-card {
+  flex: 1;
+  background: #1e1e1e;
+  border: 1px solid #2e2e2e;
+  border-radius: 0.75rem;
+  min-height: 300px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.artgen-preview-placeholder {
+  color: #666666;
+  font-size: 1.1rem;
+}
+
+.artgen-preview-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/client/src/components/artgen/loading-spinner.css
+++ b/client/src/components/artgen/loading-spinner.css
@@ -1,0 +1,16 @@
+.artgen-spinner,
+.artgen-spinner--sm {
+  border: 3px solid transparent;
+  border-top-color: #9f34ff;
+  border-radius: 50%;
+}
+
+.artgen-spinner {
+  width: 40px;
+  height: 40px;
+}
+
+.artgen-spinner--sm {
+  width: 22px;
+  height: 22px;
+}

--- a/client/src/components/artgen/prompt-form.css
+++ b/client/src/components/artgen/prompt-form.css
@@ -1,0 +1,46 @@
+.artgen-form {
+  background: #1e1e1e;
+  border: 1px solid #2e2e2e;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.artgen-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 1rem;
+  color: #ffffff;
+}
+
+.artgen-field input,
+.artgen-field select {
+  padding: 0.5rem 0.75rem;
+  background: #121212;
+  border: 1px solid #2e2e2e;
+  border-radius: 0.75rem;
+  color: #ffffff;
+}
+
+.artgen-generate-btn {
+  padding: 0.75rem;
+  background: #9f34ff;
+  border: none;
+  border-radius: 0.75rem;
+  color: #ffffff;
+  font-size: 1.05rem;
+  cursor: pointer;
+  transition: background 0.25s ease-in-out;
+}
+
+.artgen-generate-btn:disabled {
+  background: #555555;
+  cursor: not-allowed;
+}
+
+.artgen-generate-btn:hover:not(:disabled) {
+  background: #ba46ff;
+}

--- a/server/Schemas/resolvers.js
+++ b/server/Schemas/resolvers.js
@@ -131,11 +131,11 @@ const resolvers = {
       getAiImage: async (parent, {prompt}, context) => {
         try {
           const image = await openai.images.generate({
-            model: "dall-e-2",  // dall-e-2 (default) or dall-e-3
+            model: "dall-e-3",  // dall-e-2 (default) or dall-e-3
             prompt,
             n: 1, // dall-e-2 can generate up to n: 10, dall-e-3 can only use n: 1
-            size: "256x256",  // dall-e-2 sizes: "256x256", "512x512", "1024x1024" || dall-e-3 sizes: "1024x1024", "1024x1792", 1792x1024"
-            style: "natural", // vivid (default) or natural
+            size: "1024x1024",  // dall-e-2 sizes: "256x256", "512x512", "1024x1024" || dall-e-3 sizes: "1024x1024", "1024x1792", 1792x1024"
+            //style: "natural", // vivid (default) or natural
             // quality: "standard",  // standard (default) or hd
             // response_format: "url", // url (default) or b64_json
             // user: 'insertUsername' // keeps track of user who generated the image


### PR DESCRIPTION
…tegration

- Refactor ArtGen.jsx to break page into four core, reusable components: • PromptForm – handles user inputs (character, style, mood, palette, notes) • ImagePreview – displays placeholder, loading spinner, or generated image • ActionBar – “Set as Profile Picture” & “Save to Gallery” buttons • LoadingSpinner – animated spinner for both form & preview loading states
- Extract buildPrompt util for consistent prompt assembly
- Add Apollo hooks: • useLazyQuery(GET_AI_IMAGE) for image generation • useMutation(CHANGE_PROFILE_PIC) & useMutation(SAVE_AI_PIC) for backend mutations
- Wire GraphQL queries & mutations to existing resolvers; confirm URLs persist in Mongo
- Switch model to “dall‑e‑3” in resolver and rotate API key
- Create responsive CSS: • artGen.css – page‑level grid layout • component CSS (prompt-form.css, image-preview.css, action-bar.css, loading-spinner.css) for scoped styling • Enforce consistent colors, radii, and spacing across all components
- Ensure full mobile/desktop responsiveness and style organization
- Verified new images generate (non‑copyrighted), can be set as profile pic and saved to user gallery
- TODO: build out Gallery UI front‑to‑back, investigate Cloudinary uploads, and polish form error handling on API failures